### PR TITLE
feat: add optional height param to DAO vp queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "hhttps://github.com/neutron-org/neutronjsplus.git"
   },
   "scripts": {
-    "build": "rimraf ./build && tsc && mkdir ./dist/generated/ -p && cp ./src/generated/* ./dist/generated/ -r",
+    "build": "rimraf ./build && tsc && mkdir -p ./dist/generated/ && cp -r ./src/generated/* ./dist/generated/",
     "gen:proto": "mkdir ./src/generated -p && bash ./gen-proto.sh",
     "gen:proto-ibc-go": "mkdir ./src/generated -p && bash ./gen-proto-ibc-go.sh",
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neutron-org/neutronjsplus",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "Apache-2.0",

--- a/src/helpers/dao.ts
+++ b/src/helpers/dao.ts
@@ -392,22 +392,34 @@ export class Dao {
     );
   }
 
-  async queryTotalVotingPower(): Promise<TotalPowerAtHeightResponse> {
+  async queryTotalVotingPower(
+    height?: number,
+  ): Promise<TotalPowerAtHeightResponse> {
     return await this.chain.queryContract<TotalPowerAtHeightResponse>(
       this.contracts.core.address,
       {
-        total_power_at_height: {},
+        total_power_at_height:
+          typeof height === 'undefined' ? {} : { height: height },
       },
     );
   }
 
-  async queryVotingPower(addr: string): Promise<VotingPowerAtHeightResponse> {
+  async queryVotingPower(
+    addr: string,
+    height?: number,
+  ): Promise<VotingPowerAtHeightResponse> {
     return await this.chain.queryContract<VotingPowerAtHeightResponse>(
       this.contracts.core.address,
       {
-        voting_power_at_height: {
-          address: addr,
-        },
+        voting_power_at_height:
+          typeof height === 'undefined'
+            ? {
+                address: addr,
+              }
+            : {
+                address: addr,
+                height: height,
+              },
       },
     );
   }


### PR DESCRIPTION
This PR enhances dao's `queryTotalVotingPower` and `queryVotingPower` with an optional `height` to make historical queries possible.

Already published at https://www.npmjs.com/package/@neutron-org/neutronjsplus as `0.0.13`