### PR TITLE
Feat: query denoms metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neutron-org/neutronjsplus",
-  "version": "0.3.0",
+  "version": "0.3.1-rc1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neutron-org/neutronjsplus",
-  "version": "0.3.1-rc1",
+  "version": "0.3.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "Apache-2.0",

--- a/src/cosmos.ts
+++ b/src/cosmos.ts
@@ -91,6 +91,10 @@ export type DenomMetadataResponse = {
       uri_hash: string;
     },
   ];
+  pagination: {
+    next_key: string;
+    total: string;
+  };
 };
 
 // TotalBurnedNeutronsAmountResponse is the response model for the feeburner's total-burned-neutrons.

--- a/src/cosmos.ts
+++ b/src/cosmos.ts
@@ -324,10 +324,13 @@ export class CosmosWrapper {
     }
   }
 
-  async queryDenomsMetadata(): Promise<DenomMetadataResponse> {
+  async queryDenomsMetadata(
+    pagination?: PageRequest,
+  ): Promise<DenomMetadataResponse> {
     try {
       const req = await axios.get<DenomMetadataResponse>(
         `${this.sdk.url}/cosmos/bank/v1beta1/denoms_metadata`,
+        { params: pagination },
       );
       return req.data;
     } catch (e) {

--- a/src/cosmos.ts
+++ b/src/cosmos.ts
@@ -72,6 +72,27 @@ export type TotalSupplyByDenomResponse = {
   amount: ICoin;
 };
 
+export type DenomMetadataResponse = {
+  metadatas: [
+    {
+      description: string;
+      denom_units: [
+        {
+          denom: string;
+          exponent: number;
+          aliases: [string];
+        },
+      ];
+      base: string;
+      display: string;
+      name: string;
+      symbol: string;
+      uri: string;
+      uri_hash: string;
+    },
+  ];
+};
+
 // TotalBurnedNeutronsAmountResponse is the response model for the feeburner's total-burned-neutrons.
 export type TotalBurnedNeutronsAmountResponse = {
   total_burned_neutrons_amount: {
@@ -293,6 +314,20 @@ export class CosmosWrapper {
     try {
       const req = await axios.get<TotalSupplyByDenomResponse>(
         `${this.sdk.url}/cosmos/bank/v1beta1/supply/by_denom?denom=${denom}`,
+      );
+      return req.data;
+    } catch (e) {
+      if (e.response?.data?.message !== undefined) {
+        throw new Error(e.response?.data?.message);
+      }
+      throw e;
+    }
+  }
+
+  async queryDenomsMetadata(): Promise<DenomMetadataResponse> {
+    try {
+      const req = await axios.get<DenomMetadataResponse>(
+        `${this.sdk.url}/cosmos/bank/v1beta1/denoms_metadata`,
       );
       return req.data;
     } catch (e) {


### PR DESCRIPTION
This PR adds missing `ForceTransfer` and `SetDenomMetadata` messages for the TokenFactory module

Related PRs:
* https://github.com/neutron-org/neutron-integration-tests/pull/262
* https://github.com/neutron-org/neutron-sdk/pull/128
* https://github.com/neutron-org/neutron-dev-contracts/pull/39
* https://github.com/neutron-org/neutron/pull/431