### PR TITLE
Feat: whitelist ibc proposal messages

### DIFF
--- a/src/dao.ts
+++ b/src/dao.ts
@@ -1708,6 +1708,41 @@ export class DaoMember {
   }
 
   /**
+   * submitRecoverClient creates proposal to recover IBC client.
+   */
+  async submitRecoverIBCClient(
+    chainManagerAddress: string,
+    title: string,
+    description: string,
+    subjectClientId: string,
+    substituteClientId: string,
+  ): Promise<number> {
+    return await this.submitSingleChoiceProposal(
+      title,
+      description,
+      [
+        chainManagerWrapper(chainManagerAddress, {
+          custom: {
+            submit_admin_proposal: {
+              admin_proposal: {
+                proposal_execute_message: {
+                  message: JSON.stringify({
+                    '@type': '/ibc.core.client.v1.MsgRecoverClient',
+                    signer: ADMIN_MODULE_ADDRESS,
+                    subject_client_id: subjectClientId,
+                    substitute_client_id: substituteClientId,
+                  }),
+                },
+              },
+            },
+          },
+        }),
+      ],
+      '1000',
+    );
+  }
+
+  /**
    * submitCreateMarketMap creates proposal to create market map.
    */
   async submitCreateMarketMap(


### PR DESCRIPTION
We need to whitelist RecoverClient and IBCSoftwareUpgrade messages since old messages (UpdateClient and UpgradeProposal respectively) is [deprecated](https://github.com/cosmos/ibc-go/releases/tag/v8.0.0) in ibc-go v8.0+.

Related PRs:
* https://github.com/neutron-org/neutron-integration-tests/pull/297
* https://github.com/neutron-org/neutron/pull/525