### PR TITLE
chore: deprecate #ntrn-337

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,8 +1,23 @@
 export const NEUTRON_DENOM = process.env.NEUTRON_DENOM || 'untrn';
+/**
+ * @deprecated since veresion 0.5.0
+ */
 export const IBC_ATOM_DENOM = process.env.IBC_ATOM_DENOM || 'uibcatom';
+/**
+ * @deprecated since veresion 0.5.0
+ */
 export const IBC_USDC_DENOM = process.env.IBC_USDC_DENOM || 'uibcusdc';
+/**
+ * @deprecated since veresion 0.5.0
+ */
 export const COSMOS_DENOM = process.env.COSMOS_DENOM || 'uatom';
+/**
+ * @deprecated since veresion 0.5.0
+ */
 export const IBC_RELAYER_NEUTRON_ADDRESS =
   'neutron1mjk79fjjgpplak5wq838w0yd982gzkyf8fxu8u';
+/**
+ * @deprecated since veresion 0.5.0
+ */
 export const ADMIN_MODULE_ADDRESS =
   'neutron1hxskfdxpp5hqgtjj6am6nkjefhfzj359x0ar3z';

--- a/src/cosmos.ts
+++ b/src/cosmos.ts
@@ -165,6 +165,9 @@ export class CosmosWrapper {
     return res.balances;
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async queryDenomBalance(addr: string, denom: string): Promise<number> {
     // TODO: fixme don't connect every time
     const client = await connectComet(this.rpc);
@@ -179,6 +182,9 @@ export class CosmosWrapper {
     return parseInt(res?.balance.amount ?? '0', 10);
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async getHeight(): Promise<number> {
     // TODO: fixme don't connect every time
     const client = await connectComet(this.rpc);
@@ -187,6 +193,9 @@ export class CosmosWrapper {
     return +block.block.header.height;
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async waitBlocks(blocks: number, timeout = 120000): Promise<void> {
     const start = Date.now();
     const client = await StargateClient.connect(this.rpc);
@@ -208,6 +217,9 @@ export class CosmosWrapper {
     }
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async queryDenomTrace(ibcDenom: string): Promise<DenomTraceResponse> {
     const data = axios.get<{ denom_trace: DenomTraceResponse }>(
       `${this.rest}/ibc/apps/transfer/v1/denom_traces/${ibcDenom}`,
@@ -215,6 +227,9 @@ export class CosmosWrapper {
     return data.then((res) => res.data.denom_trace);
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async queryAckFailures(
     addr: string,
     pagination?: PageRequest,
@@ -233,6 +248,9 @@ export class CosmosWrapper {
     }
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async listIBCChannels(): Promise<ChannelsList> {
     const res = await axios.get<ChannelsList>(
       `${this.rest}/ibc/core/channel/v1/channels`,
@@ -240,6 +258,9 @@ export class CosmosWrapper {
     return res.data;
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async getIBCClientStatus(clientId: string): Promise<IBCClientStatus> {
     const res = await axios.get<IBCClientStatus>(
       `${this.rest}/ibc/core/client/v1/client_status/${clientId}`,
@@ -247,6 +268,9 @@ export class CosmosWrapper {
     return res.data;
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async queryTotalBurnedNeutronsAmount(): Promise<TotalBurnedNeutronsAmountResponse> {
     try {
       const req = await axios.get<TotalBurnedNeutronsAmountResponse>(
@@ -261,6 +285,9 @@ export class CosmosWrapper {
     }
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async queryTotalSupplyByDenom(
     denom: string,
   ): Promise<TotalSupplyByDenomResponse> {
@@ -277,6 +304,9 @@ export class CosmosWrapper {
     }
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async queryDenomsMetadata(
     pagination?: PageRequest,
   ): Promise<DenomMetadataResponse> {
@@ -294,6 +324,9 @@ export class CosmosWrapper {
     }
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async getChainAdmins() {
     const url = `${this.rest}/cosmos/adminmodule/adminmodule/admins`;
     const resp = await axios.get<{
@@ -302,6 +335,10 @@ export class CosmosWrapper {
     return resp.data.admins;
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
+  // TODO: do not belong here - move out to the dao.ts or something
   async getNeutronDAOCore() {
     const chainManager = (await this.getChainAdmins())[0];
     const strategies = await this.queryContract<[string, Strategy][]>(
@@ -313,12 +350,20 @@ export class CosmosWrapper {
     return strategies[0][0];
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
+  // TODO: do not belong here - move out to the dao.ts or something
   async queryPausedInfo(addr: string): Promise<PauseInfoResponse> {
     return await this.queryContract<PauseInfoResponse>(addr, {
       pause_info: {},
     });
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
+  // TODO: do not belong here - move to test helpers
   async getWithAttempts<T>(
     getFunc: () => Promise<T>,
     readyFunc: (t: T) => Promise<boolean>,
@@ -346,6 +391,9 @@ export class CosmosWrapper {
         );
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async getCodeDataHash(codeId: number): Promise<string> {
     try {
       const res = await axios.get(
@@ -360,6 +408,9 @@ export class CosmosWrapper {
     }
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async querySchedules(pagination?: PageRequest): Promise<ScheduleResponse> {
     try {
       const req = await axios.get<ScheduleResponse>(
@@ -375,6 +426,9 @@ export class CosmosWrapper {
     }
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async queryCurrentUpgradePlan(): Promise<CurrentPlanResponse> {
     try {
       const req = await axios.get<CurrentPlanResponse>(
@@ -390,6 +444,9 @@ export class CosmosWrapper {
     }
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async queryPinnedCodes(): Promise<PinnedCodesResponse> {
     try {
       const req = await axios.get<PinnedCodesResponse>(
@@ -405,6 +462,9 @@ export class CosmosWrapper {
     }
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async queryHostEnabled(): Promise<boolean> {
     try {
       const req = await axios.get<IcaHostParamsResponse>(
@@ -420,6 +480,9 @@ export class CosmosWrapper {
     }
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async queryMaxTxsAllowed(): Promise<string> {
     try {
       const req = await axios.get<InterchaintxsParamsResponse>(
@@ -435,12 +498,18 @@ export class CosmosWrapper {
     }
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async queryGlobalfeeParams(): Promise<GlobalfeeParamsResponse> {
     const req = await axios.get(`${this.rest}/gaia/globalfee/v1beta1/params`);
 
     return req.data.params;
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async getGasPrice(denom: string): Promise<GasPriceResponse> {
     const res = await axios.get<GasPriceResponse>(
       `${this.rest}/feemarket/v1/gas_price/${denom}`,
@@ -449,6 +518,9 @@ export class CosmosWrapper {
     return res.data;
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async getGasPrices(): Promise<GasPricesResponse> {
     const res = await axios.get<GasPricesResponse>(
       `${this.rest}/feemarket/v1/gas_prices`,
@@ -457,6 +529,9 @@ export class CosmosWrapper {
     return res.data;
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async getDynamicFeesRaparms(): Promise<DynamicFeesParamsResponse> {
     const res = await axios.get<DynamicFeesParamsResponse>(
       `${this.rest}/neutron/dynamicfees/v1/params`,
@@ -465,6 +540,9 @@ export class CosmosWrapper {
     return res.data;
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async getFeemarketParams(): Promise<FeeMarketParamsResponse> {
     const res = await axios.get<FeeMarketParamsResponse>(
       `${this.rest}/feemarket/v1/params`,
@@ -473,11 +551,17 @@ export class CosmosWrapper {
     return res.data;
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async queryContractAdmin(address: string): Promise<string> {
     const resp = await this.getContractInfo(address);
     return resp.contract_info.admin;
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async queryOraclePrice(
     base: string,
     quote: string,
@@ -501,6 +585,9 @@ export class CosmosWrapper {
     }
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async queryOraclePrices(
     currencyPairIds: string[],
   ): Promise<GetPricesResponse> {
@@ -511,6 +598,9 @@ export class CosmosWrapper {
     return req.data;
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async queryOracleAllCurrencyPairs(): Promise<GetAllCurrencyPairsResponse> {
     const req = await axios.get(
       `${this.rest}/slinky/oracle/v1/get_all_tickers`,
@@ -520,6 +610,10 @@ export class CosmosWrapper {
   }
 }
 
+// TODO: move out to some helpers
+/**
+ * @deprecated since version 0.5.0
+ */
 export const getEventAttributesFromTx = (
   data: any,
   event: string,
@@ -562,6 +656,10 @@ export const getSequenceId = (tx: IndexedTx | undefined): number => {
   }
 };
 
+// TODO: move out to IBC helpers
+/**
+ * @deprecated since version 0.5.0
+ */
 export const getIBCDenom = (portName, channelName, denom: string): string => {
   const uatomIBCHash = crypto
     .createHash('sha256')
@@ -571,6 +669,10 @@ export const getIBCDenom = (portName, channelName, denom: string): string => {
   return `ibc/${uatomIBCHash}`;
 };
 
+// TODO: move to dao helpers
+/**
+ * @deprecated since version 0.5.0
+ */
 export const createBankSendMessage = (
   addr: string,
   amount: number,
@@ -589,6 +691,10 @@ export const createBankSendMessage = (
   },
 });
 
+// TODO: move to helpers
+/**
+ * @deprecated since version 0.5.0
+ */
 export const getEventAttribute = (
   events: readonly CosmosEvent[],
   eventType: string,
@@ -609,10 +715,18 @@ export const getEventAttribute = (
   return attrValue;
 };
 
+// TODO: move out to IBC helpers
+/**
+ * @deprecated since version 0.5.0
+ */
 export const filterIBCDenoms = (list: Coin[]) =>
   list.filter(
     (coin) =>
       coin.denom && ![IBC_ATOM_DENOM, IBC_USDC_DENOM].includes(coin.denom),
   );
 
+// TODO: move to dao helpers
+/**
+ * @deprecated since version 0.5.0
+ */
 export const wrapMsg = (x) => Buffer.from(JSON.stringify(x)).toString('base64');

--- a/src/cosmos.ts
+++ b/src/cosmos.ts
@@ -155,7 +155,6 @@ export class CosmosWrapper {
 
   /**
    * @deprecated since version 0.5.0
-   * use StargateClient.getAllBalances("address") instead
    */
   async queryBalances(addr: string): Promise<Coin[]> {
     // TODO: fixme don't connect every time

--- a/src/cosmos.ts
+++ b/src/cosmos.ts
@@ -153,6 +153,10 @@ export class CosmosWrapper {
     return req.data;
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   * use StargateClient.getAllBalances("address") instead
+   */
   async queryBalances(addr: string): Promise<Coin[]> {
     // TODO: fixme don't connect every time
     const client = await connectComet(this.rpc);

--- a/src/dao.ts
+++ b/src/dao.ts
@@ -43,6 +43,10 @@ import { ClientState } from '@neutron-org/cosmjs-types/ibc/lightclients/tendermi
 import { ADMIN_MODULE_ADDRESS } from './constants';
 import { DynamicFeesParams, FeeMarketParams } from './feemarket';
 
+// TODO:: move to neutron-integration-tests dao testing helpers
+/**
+ * @deprecated since version 0.5.0
+ */
 export type SubdaoProposalConfig = {
   threshold: any;
   max_voting_period: Duration;
@@ -52,6 +56,10 @@ export type SubdaoProposalConfig = {
   close_proposal_on_execution_failure: boolean;
 };
 
+// TODO:: move to neutron-integration-tests dao testing helpers
+/**
+ * @deprecated since version 0.5.0
+ */
 export type Duration = {
   height: number | null;
   time: number | null;
@@ -170,6 +178,10 @@ export type NewMarkets = {
   }[];
 }[];
 
+// TODO:: move to neutron-integration-tests dao testing deploy
+/**
+ * @deprecated since version 0.5.0
+ */
 export const DaoContractLabels = {
   DAO_CORE: 'neutron.core',
   NEUTRON_VAULT: 'neutron.voting.vaults.neutron',
@@ -185,6 +197,10 @@ export const DaoContractLabels = {
   DAO_PROPOSAL_OVERRULE: 'neutron.proposals.overrule',
 };
 
+// TODO:: move to neutron-integration-tests dao testing deploy
+/**
+ * @deprecated since version 0.5.0
+ */
 export const DaoPrefixes = {
   'Neutron DAO': 'neutron',
   'Security SubDAO': 'security',
@@ -355,6 +371,10 @@ export const getSubDaoContracts = async (
   };
 };
 
+// TODO:: remove and use native rpc query client
+/**
+ * @deprecated since version 0.5.0
+ */
 export const getTreasuryContract = async (
   cm: CosmosWrapper,
 ): Promise<string> => {
@@ -468,6 +488,10 @@ export class Dao {
     );
   }
 
+  // TODO: move to neutron-integration-tests dao helpers
+  /**
+   * @deprecated since version 0.5.0
+   */
   async makeSingleChoiceProposalPass(
     loyalVoters: DaoMember[],
     title: string,
@@ -733,6 +757,7 @@ export class DaoMember {
     );
   }
 
+  // TODO: description
   async executeProposalWithAttempts(
     proposalId: number,
     fee = {
@@ -748,6 +773,7 @@ export class DaoMember {
     );
   }
 
+  // TODO: description
   async executeMultiChoiceProposalWithAttempts(proposalId: number) {
     await this.executeMultiChoiceProposal(proposalId);
     await this.user.chain.getWithAttempts(
@@ -1079,6 +1105,10 @@ export class DaoMember {
     );
   }
 
+  // TODO: move to neutron-integration-tests
+  /**
+   * @deprecated since version 0.5.0
+   */
   async supportAndExecuteProposal(
     proposalId: number,
     customModule = 'single',
@@ -1088,6 +1118,7 @@ export class DaoMember {
     return await this.dao.getTimelockedProposal(proposalId, customModule);
   }
 
+  // TODO: description
   async executeTimelockedProposal(
     proposalId: number,
     customModule = 'single',
@@ -1102,6 +1133,10 @@ export class DaoMember {
     );
   }
 
+  // TODO: optional: move to tests only functionality?
+  /**
+   * @deprecated since version 0.5.0
+   */
   async overruleTimelockedProposal(
     timelockAddress: string,
     proposalId: number,
@@ -1164,6 +1199,7 @@ export class DaoMember {
     return proposalId1;
   }
 
+  // TODO: description
   async submitUpdateConfigProposal(
     title: string,
     description: string,
@@ -1191,6 +1227,7 @@ export class DaoMember {
     );
   }
 
+  // TODO: description
   async submitUpdateSubDaoConfigProposal(
     newConfig: {
       name?: string;
@@ -1220,6 +1257,7 @@ export class DaoMember {
     );
   }
 
+  // TODO: description
   async submitTypedPauseProposal(
     contractAddr: string,
     duration = 10,
@@ -1248,6 +1286,7 @@ export class DaoMember {
     );
   }
 
+  // TODO: description
   async submitUntypedPauseProposal(
     contractAddr: string,
     duration = 10,
@@ -1276,6 +1315,7 @@ export class DaoMember {
     );
   }
 
+  // TODO: description
   async submitUntypedPauseProposalWFunds(
     contractAddr: string,
     duration = 10,
@@ -1306,6 +1346,7 @@ export class DaoMember {
     );
   }
 
+  // TODO: description
   async submitUpdateSubDaoMultisigParticipants(
     newParticipants: string[],
   ): Promise<number> {
@@ -1394,7 +1435,6 @@ export class DaoMember {
   /**
    * submitUnpinCodesProposal creates proposal which unpins given code ids to wasmvm.
    */
-
   async submitUnpinCodesProposal(
     chainManagerAddress: string,
     title: string,
@@ -1421,7 +1461,6 @@ export class DaoMember {
   /**
    * submitUpdateParamsInterchaintxsProposal creates proposal which changes params of interchaintxs module.
    */
-
   async submitUpdateParamsInterchaintxsProposal(
     chainManagerAddress: string,
     title: string,
@@ -1455,7 +1494,6 @@ export class DaoMember {
   /**
    * submitUpdateParamsTransferProposal creates proposal which changes params of transfer module.
    */
-
   async submitUpdateParamsTransferProposal(
     chainManagerAddress: string,
     title: string,
@@ -1486,6 +1524,7 @@ export class DaoMember {
     );
   }
 
+  // TODO: description
   async submitUpdateParamsGlobalfeeProposal(
     chainManagerAddress: string,
     title: string,
@@ -1510,7 +1549,6 @@ export class DaoMember {
   /**
    * submitUpdateParamsInterchainqueriesProposal creates proposal which changes params of interchaintxs module.
    */
-
   async submitUpdateParamsInterchainqueriesProposal(
     chainManagerAddress: string,
     title: string,
@@ -1526,6 +1564,7 @@ export class DaoMember {
     );
   }
 
+  // TODO: description
   async submitAddChainManagerStrategyProposal(
     chainManagerAddress: string,
     title: string,
@@ -1553,7 +1592,6 @@ export class DaoMember {
   /**
    * submitUpdateParamsTokenfactoryProposal creates proposal which changes params of tokenfactory module.
    */
-
   async submitUpdateParamsTokenfactoryProposal(
     chainManagerAddress: string,
     title: string,
@@ -1572,7 +1610,6 @@ export class DaoMember {
   /**
    * submitUpdateParamsFeeburnerProposal creates proposal which changes some params of feeburner module.
    */
-
   async submitUpdateParamsFeeburnerProposal(
     chainManagerAddress: string,
     title: string,
@@ -1591,7 +1628,6 @@ export class DaoMember {
   /**
    * submitUpdateParamsFeerefunderProposal creates proposal which changes some params of feerefunder module.
    */
-
   async submitUpdateParamsFeerefunderProposal(
     chainManagerAddress: string,
     title: string,
@@ -1612,7 +1648,6 @@ export class DaoMember {
   /**
    * submitUpdateParamsCronProposal creates proposal which changes soe params of cron module.
    */
-
   async submitUpdateParamsCronProposal(
     chainManagerAddress: string,
     title: string,
@@ -1631,7 +1666,6 @@ export class DaoMember {
   /**
    * submitUpdateParamsContractmanagerProposal creates proposal which changes some params of contractmanager module.
    */
-
   async submitUpdateParamsContractmanagerProposal(
     chainManagerAddress: string,
     title: string,
@@ -1915,12 +1949,17 @@ export class DaoMember {
     );
   }
 
+  // TODO: description
   async queryVotingPower(
     height?: number,
   ): Promise<VotingPowerAtHeightResponse> {
     return await this.dao.queryVotingPower(this.user.wallet.address, height);
   }
 
+  // TODO: optional: move to neutron-integration-tests helpers
+  /**
+   * @deprecated since version 0.5.0
+   */
   async addSubdaoToDao(subDaoCore: string) {
     const p = await this.submitSingleChoiceProposal(
       'add subdao',
@@ -1933,6 +1972,10 @@ export class DaoMember {
   }
 }
 
+// TODO: optional: move to neutron-integration-tests helpers
+/**
+ * @deprecated since version 0.5.0
+ */
 export const deploySubdao = async (
   cm: WalletWrapper,
   mainDaoCoreAddress: string,
@@ -2071,6 +2114,10 @@ export const deploySubdao = async (
   return new Dao(cm.chain, await getSubDaoContracts(cm.chain, coreDaoContract));
 };
 
+// TODO: optional: move to neutron-integration-tests helpers
+/**
+ * @deprecated since version 0.5.0
+ */
 export const setupSubDaoTimelockSet = async (
   cm: WalletWrapper,
   mainDaoAddress: string,
@@ -2093,6 +2140,10 @@ export const setupSubDaoTimelockSet = async (
   return subDao;
 };
 
+// TODO: optional: move to neutron-integration-tests helpers
+/**
+ * @deprecated since version 0.5.0
+ */
 export const deployNeutronDao = async (
   cm: WalletWrapper,
 ): Promise<DaoContracts> => {

--- a/src/dex.ts
+++ b/src/dex.ts
@@ -3,66 +3,108 @@ import { Coin } from '@neutron-org/cosmjs-types/cosmos/base/v1beta1/coin';
 
 // DEX queries
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type ParamsResponse = {
   params: Params;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type LimitOrderTrancheUserResponse = {
   limit_order_tranche_user?: LimitOrderTrancheUser;
   withdrawable_shares?: string;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type AllLimitOrderTrancheUserResponse = {
   limit_order_tranche_user: LimitOrderTrancheUser[];
   pagination?: PageResponse;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type AllUserLimitOrdersResponse = {
   limit_orders: LimitOrderTrancheUser[];
   pagination?: PageResponse;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type LimitOrderTrancheResponse = {
   limit_order_tranche?: LimitOrderTranche;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type AllLimitOrderTrancheResponse = {
   limit_order_tranche: LimitOrderTranche[];
   pagination?: PageResponse;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type AllUserDepositsResponse = {
   deposits: DepositRecord[];
   pagination?: PageResponse;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type AllTickLiquidityResponse = {
   tick_liquidity: TickLiquidity[];
   pagination?: PageResponse;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type InactiveLimitOrderTrancheResponse = {
   inactive_limit_order_tranche: LimitOrderTranche;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type AllInactiveLimitOrderTrancheResponse = {
   inactive_limit_order_tranche: LimitOrderTranche[];
   pagination?: PageResponse;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type AllPoolReservesResponse = {
   pool_reserves: PoolReserves[];
   pagination?: PageResponse;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type PoolReservesResponse = {
   pool_reserves: PoolReserves;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type EstimateMultiHopSwapResponse = {
   coin_out: Coin;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type EstimatePlaceLimitOrderResponse = {
   // Total amount of coin used for the limit order
   // You can derive makerLimitInCoin using the equation: totalInCoin = swapInCoin + makerLimitInCoin
@@ -75,21 +117,32 @@ export type EstimatePlaceLimitOrderResponse = {
   swap_out_coin: Coin;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type PoolResponse = {
   pool: Pool;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type PoolMetadataResponse = {
   pool_metadata: PoolMetadata;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type AllPoolMetadataResponse = {
   pool_metadata: PoolMetadata[];
   pagination?: PageResponse;
 };
 
 // types
-
+/**
+ * @deprecated since version 0.5.0
+ */
 export enum LimitOrderType {
   GoodTilCanceled = 0,
   FillOrKill = 1,
@@ -98,10 +151,16 @@ export enum LimitOrderType {
   GoodTilTime = 4,
 }
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type MultiHopRoute = {
   hops: string[];
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type LimitOrderTrancheUser = {
   trade_pair_id: TradePairID;
   tick_index_taker_to_maker: string; // Int64
@@ -113,16 +172,25 @@ export type LimitOrderTrancheUser = {
   order_type: LimitOrderType;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type TradePairID = {
   maker_denom: string;
   taker_denom: string;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type Params = {
   fee_tiers: string[]; // Uint64
   max_true_taker_spread: string; // PrecDec
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type LimitOrderTranche = {
   key: LimitOrderTrancheKey;
   reserves_maker_denom: string; // Int128
@@ -133,12 +201,18 @@ export type LimitOrderTranche = {
   price_taker_to_maker: string; // PrecDec
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type LimitOrderTrancheKey = {
   trade_pair_id: TradePairID;
   tick_index_taker_to_maker: string; // Int64
   tranche_key: string;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type DepositRecord = {
   pair_id: PairID;
   shares_owned: string; // Int128
@@ -150,15 +224,24 @@ export type DepositRecord = {
   pool?: Pool; // Option<Pool>
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type PairID = {
   token0: string;
   token1: string;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type TickLiquidity =
   | { pool_reserves: PoolReserves }
   | { limit_order_tranche: LimitOrderTranche };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type PoolReserves = {
   key: PoolReservesKey;
   reserves_maker_denom: string; // Int128
@@ -166,18 +249,27 @@ export type PoolReserves = {
   price_opposite_taker_to_maker: string; // PrecDec
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type PoolReservesKey = {
   trade_pair_id: TradePairID;
   tick_index_taker_to_maker: string; // Int64
   fee?: string; // Option<Uint64>
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type Pool = {
   id: string; // Uint64
   lower_tick0: PoolReserves;
   lower_tick1: PoolReserves;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type PoolMetadata = {
   id: string; // Uint64
   tick: string; // Int64

--- a/src/ica.ts
+++ b/src/ica.ts
@@ -1,5 +1,9 @@
 import { CosmosWrapper } from './cosmos';
 
+// TODO: move to interchain tx tests
+/**
+ * @deprecated since version 0.5.0
+ */
 export const getIca = (
   cm: CosmosWrapper,
   contractAddress: string,

--- a/src/icq.ts
+++ b/src/icq.ts
@@ -2,7 +2,10 @@ import axios, { AxiosResponse } from 'axios';
 import { CosmosWrapper } from './cosmos';
 import { WalletWrapper } from './walletWrapper';
 
+// TODO: move to helpers for neutron_interchain_queries contract
 /**
+ * @deprecated since version 0.5.0
+ *
  * getRegisteredQuery queries the contract for a registered query details registered by the given
  * queryId.
  */
@@ -38,7 +41,10 @@ export const getRegisteredQuery = (
     },
   });
 
+// TODO: move to helpers for neutron_interchain_queries contract
 /**
+ * @deprecated since version 0.5.0
+ *
  * waitForICQResultWithRemoteHeight waits until ICQ gets updated to
  * reflect data corresponding to remote height `>= targetHeight`
  */
@@ -57,7 +63,9 @@ export const waitForICQResultWithRemoteHeight = (
     numAttempts,
   );
 
+// TODO: move to helpers for neutron_interchain_queries contract
 /**
+ * @deprecated since version 0.5.0
  * queryTransfersNumber queries the contract for recorded transfers number.
  */
 export const queryTransfersNumber = (
@@ -70,7 +78,10 @@ export const queryTransfersNumber = (
     get_transfers_number: {},
   });
 
+// TODO: move to helpers for neutron_interchain_queries contract
 /**
+ *
+ * @deprecated since version 0.5.0
  * waitForTransfersAmount waits until contract has `expectedTransfersAmount`
  * number of incoming transfers stored.
  */
@@ -87,6 +98,7 @@ export const waitForTransfersAmount = (
     numAttempts,
   );
 
+// TODO: description
 type UnsuccessfulSubmitIcqTx = {
   // QueryID is the query_id transactions was submitted for
   query_id: number;
@@ -102,11 +114,13 @@ type UnsuccessfulSubmitIcqTx = {
   message: string;
 };
 
+// TODO: description
 export type ResubmitQuery = {
   query_id: number;
   hash: string;
 };
 
+// TODO: description
 export const getUnsuccessfulTxs = async (
   icqWebHost: string,
 ): Promise<Array<UnsuccessfulSubmitIcqTx>> => {
@@ -115,6 +129,7 @@ export const getUnsuccessfulTxs = async (
   return req.data;
 };
 
+// TODO: description
 export const postResubmitTxs = async (
   icqWebHost: string,
   txs: Array<ResubmitQuery>,
@@ -124,7 +139,10 @@ export const postResubmitTxs = async (
   return await axios.post(url, data);
 };
 
+// TODO: move to helpers for neutron_interchain_queries contract
 /**
+ * @deprecated since version 0.5.0
+ *
  * registerTransfersQuery sends a register_transfers_query execute msg to the contractAddress with
  * the given parameters and checks the tx result to be successful.
  */
@@ -148,7 +166,10 @@ export const registerTransfersQuery = async (
   }
 };
 
+// TODO: move to helpers for neutron_interchain_queries contract
 /**
+ * @deprecated since version 0.5.0
+ *
  * queryRecipientTxs queries the contract for recorded transfers to the given recipient address.
  */
 export const queryRecipientTxs = (

--- a/src/marketmap.ts
+++ b/src/marketmap.ts
@@ -1,16 +1,28 @@
+/**
+ * @deprecated since version 0.5.0
+ */
 export type ParamsResponse = {
   params: Params;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type CurrencyPair = {
   base: string;
   quote: string;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type LastUpdatedResponse = {
   last_updated: number;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type MarketMapResponse = {
   // MarketMap defines the global set of market configurations for all providers
   // and markets.
@@ -23,10 +35,16 @@ export type MarketMapResponse = {
   chain_id: string;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type MarketResponse = {
   market: Market;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type QuotePrice = {
   price: string;
   // // BlockTimestamp tracks the block height associated with this price update.
@@ -37,15 +55,24 @@ export type QuotePrice = {
   block_height: number;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type Params = {
   admin: string;
   market_authorities: string[];
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type MarketMap = {
   markets: Map<string, Market>;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type Market = {
   // Tickers is the full list of tickers and their associated configurations
   // to be stored on-chain.
@@ -55,6 +82,9 @@ export type Market = {
   provider_configs: Map<string, ProviderConfig>;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type ProviderConfig = {
   // Name corresponds to the name of the provider for which the configuration is
   // being set.
@@ -76,6 +106,9 @@ export type ProviderConfig = {
   metadata_json: string;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type Ticker = {
   // CurrencyPair is the currency pair for this ticker.
   currency_pair: CurrencyPair;

--- a/src/neutronTypes.ts
+++ b/src/neutronTypes.ts
@@ -13,6 +13,7 @@ import {
 } from '@neutron-org/cosmjs-types/osmosis/tokenfactory/v1beta1/tx';
 import { MsgAuctionBid } from '@neutron-org/cosmjs-types/sdk/auction/v1/tx';
 
+// TODO: use all types from @neutron-org/neutronjs library
 export const neutronTypes: ReadonlyArray<[string, GeneratedType]> = [
   ...defaultRegistryTypes,
   ...wasmTypes,

--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -1,3 +1,6 @@
+/**
+ * @deprecated since version 0.5.0
+ */
 export type GetPriceResponse = {
   price: {
     price: string;
@@ -9,15 +12,24 @@ export type GetPriceResponse = {
   id: string;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type GetPricesResponse = {
   prices: GetPriceResponse[];
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type CurrencyPair = {
   Quote: string;
   Base: string;
 };
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export type GetAllCurrencyPairsResponse = {
   currency_pairs: CurrencyPair[];
 };

--- a/src/proposal.ts
+++ b/src/proposal.ts
@@ -106,7 +106,9 @@ export type SendProposalInfo = {
 };
 
 export type MultiChoiceProposal = {
+  // Title  of the proposal
   readonly title: string;
+  // Description of the proposal
   readonly description: string;
   // The address that created this proposal.
   readonly proposer: string;

--- a/src/tge.ts
+++ b/src/tge.ts
@@ -33,6 +33,10 @@ const sha256 = (x: string): Buffer => {
   return hash.digest();
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export class Airdrop {
   private tree: MerkleTree;
 
@@ -55,6 +59,10 @@ export class Airdrop {
   }
 }
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const getTimestamp = (secondsFromNow: number): number =>
   (Date.now() / 1000 + secondsFromNow) | 0;
 
@@ -83,6 +91,11 @@ export const getTimestamp = (secondsFromNow: number): number =>
  * await tge.deployLockdrop();
  * await tge.deployLockdropVault();
  *
+ */
+
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
  */
 export class Tge {
   chain: CosmosWrapper;
@@ -609,6 +622,10 @@ export class Tge {
   }
 }
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const instantiateAuction = async (
   cm: WalletWrapper,
   codeId: CodeId,
@@ -656,6 +673,10 @@ export const instantiateAuction = async (
   return res;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const instantiateAirdrop = async (
   cm: WalletWrapper,
   codeId: CodeId,
@@ -689,6 +710,10 @@ export const instantiateAirdrop = async (
   return res;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const executeAuctionUpdateConfig = async (
   cm: WalletWrapper,
   contractAddress: string,
@@ -709,6 +734,10 @@ export const executeAuctionUpdateConfig = async (
     },
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const executeAuctionSetTokenInfo = async (
   cm: WalletWrapper,
   contractAddress: string,
@@ -722,6 +751,10 @@ export const executeAuctionSetTokenInfo = async (
     },
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const instantiateCredits = async (
   cm: WalletWrapper,
   codeId: CodeId,
@@ -741,6 +774,10 @@ export const instantiateCredits = async (
   return res;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const executeCreditsUpdateConfig = async (
   cm: WalletWrapper,
   contractAddress: string,
@@ -756,6 +793,10 @@ export const executeCreditsUpdateConfig = async (
     },
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const executeCreditsMint = async (
   cm: WalletWrapper,
   contractAddress: string,
@@ -775,6 +816,10 @@ export const executeCreditsMint = async (
     ],
   );
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const instantiateCreditsVault = async (
   cm: WalletWrapper,
   codeId: CodeId,
@@ -802,6 +847,10 @@ export const instantiateCreditsVault = async (
   return res;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const executeCreditsVaultUpdateConfig = async (
   cm: WalletWrapper,
   contractAddress: string,
@@ -819,6 +868,10 @@ export const executeCreditsVaultUpdateConfig = async (
     },
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const queryCreditsVaultConfig = async (
   cm: CosmosWrapper,
   contractAddress: string,
@@ -827,11 +880,19 @@ export const queryCreditsVaultConfig = async (
     config: {},
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export type LockupRewardsInfo = {
   duration: number;
   coefficient: string;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export type LockdropLockUpInfoResponse = {
   astroport_lp_token: string;
   astroport_lp_transferred: string | null;
@@ -848,6 +909,10 @@ export type LockdropLockUpInfoResponse = {
   withdrawal_flag: boolean;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export type LockdropUserInfoResponse = {
   claimable_generator_ntrn_debt: string;
   lockup_infos: LockdropLockUpInfoResponse[];
@@ -856,6 +921,10 @@ export type LockdropUserInfoResponse = {
   total_ntrn_rewards: string;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export type LockdropPclUserInfoResponse = {
   claimable_incentives_debt: [Token | NativeToken, string][]; // RestrictedVector<AssetInfo, Uint128>
   lockup_infos: LockdropPclLockUpInfoResponse[];
@@ -864,6 +933,10 @@ export type LockdropPclUserInfoResponse = {
   total_ntrn_rewards: string;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export type LockdropPclLockUpInfoResponse = {
   pool_type: string;
   lp_units_locked: string; // Uint128
@@ -878,6 +951,10 @@ export type LockdropPclLockUpInfoResponse = {
   astroport_lp_transferred: string | null;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export type LockdropXykPool = {
   lp_token: string;
   amount_in_lockups: string; // Uint128
@@ -888,6 +965,10 @@ export type LockdropXykPool = {
   is_staked: boolean;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export type LockdropPclPool = {
   lp_token: string;
   amount_in_lockups: string; // Uint128
@@ -897,6 +978,10 @@ export type LockdropPclPool = {
   is_staked: boolean;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const instantiateLockdrop = async (
   cm: WalletWrapper,
   codeId: CodeId,
@@ -936,6 +1021,10 @@ export const instantiateLockdrop = async (
   return res;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const queryXykLockdropUserInfo = async (
   chain: CosmosWrapper,
   contractAddress: string,
@@ -945,6 +1034,10 @@ export const queryXykLockdropUserInfo = async (
     user_info: { address: userAddress },
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const queryPclLockdropUserInfo = async (
   chain: CosmosWrapper,
   contractAddress: string,
@@ -954,6 +1047,10 @@ export const queryPclLockdropUserInfo = async (
     user_info: { address: userAddress },
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const queryXykLockdropConfig = (
   chain: CosmosWrapper,
   contractAddress: string,
@@ -962,6 +1059,10 @@ export const queryXykLockdropConfig = (
     config: {},
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export type XykLockdropConfig = {
   owner: string;
   token_info_manager: string;
@@ -978,6 +1079,10 @@ export type XykLockdropConfig = {
   lockup_rewards_info: LockupRewardsInfo[];
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const queryPclLockdropConfig = (
   chain: CosmosWrapper,
   contractAddress: string,
@@ -986,6 +1091,10 @@ export const queryPclLockdropConfig = (
     config: {},
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export type PclLockdropConfig = {
   owner: string;
   xyk_lockdrop_contract: string;
@@ -996,6 +1105,10 @@ export type PclLockdropConfig = {
   lockup_rewards_info: LockupRewardsInfo[];
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const queryXykLockdropPool = (
   chain: CosmosWrapper,
   contractAddress: string,
@@ -1005,6 +1118,10 @@ export const queryXykLockdropPool = (
     pool: { pool_type: poolType },
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const queryPclLockdropPool = (
   chain: CosmosWrapper,
   contractAddress: string,
@@ -1014,6 +1131,10 @@ export const queryPclLockdropPool = (
     pool: { pool_type: poolType },
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const executeLockdropUpdateConfig = async (
   cm: WalletWrapper,
   contractAddress: string,
@@ -1027,6 +1148,10 @@ export const executeLockdropUpdateConfig = async (
     },
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const executeLockdropSetTokenInfo = async (
   cm: WalletWrapper,
   contractAddress: string,
@@ -1042,6 +1167,10 @@ export const executeLockdropSetTokenInfo = async (
     },
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const instantiatePriceFeed = async (
   cm: WalletWrapper,
   codeId: CodeId,
@@ -1054,6 +1183,10 @@ export const instantiatePriceFeed = async (
   return res;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const instantiateCoinRegistry = async (
   cm: WalletWrapper,
   codeId: CodeId,
@@ -1072,6 +1205,10 @@ export const instantiateCoinRegistry = async (
   return res;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const instantiateAstroFactory = async (
   cm: WalletWrapper,
   codeId: CodeId,
@@ -1119,6 +1256,10 @@ export const instantiateAstroFactory = async (
   return res;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const executeFactoryCreatePair = async (
   cm: WalletWrapper,
   contractAddress: string,
@@ -1145,6 +1286,10 @@ export const executeFactoryCreatePair = async (
     },
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export type PairInfo = {
   asset_infos: Record<'native_token' | 'token', { denom: string }>[];
   contract_addr: string;
@@ -1152,10 +1297,18 @@ export type PairInfo = {
   pair_type: Record<string, object>;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export type FactoryPairsResponse = {
   pairs: PairInfo[];
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const queryFactoryPairs = async (
   chain: CosmosWrapper,
   contractAddress: string,
@@ -1164,6 +1317,10 @@ export const queryFactoryPairs = async (
     pairs: {},
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const instantiateAstroVesting = async (
   cm: WalletWrapper,
   codeId: CodeId,
@@ -1184,6 +1341,10 @@ export const instantiateAstroVesting = async (
   return res;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export type VestingAccountResponse = {
   address: string;
   info: {
@@ -1195,6 +1356,10 @@ export type VestingAccountResponse = {
   };
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 type GeneratorRewardsState = {
   balanceNtrn: number;
   balanceAstro: number;
@@ -1203,6 +1368,10 @@ type GeneratorRewardsState = {
   usdcNtrnLpTokenBalance: number;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const queryTotalUnclaimedAmountAtHeight = async (
   chain: CosmosWrapper,
   address: string,
@@ -1218,6 +1387,10 @@ export const queryTotalUnclaimedAmountAtHeight = async (
     },
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const queryNtrnCLBalanceAtHeight = async (
   chain: CosmosWrapper,
   address: string,
@@ -1234,6 +1407,10 @@ export const queryNtrnCLBalanceAtHeight = async (
     },
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const queryUnclaimmedAmountAtHeight = async (
   chain: CosmosWrapper,
   address: string,
@@ -1251,6 +1428,10 @@ export const queryUnclaimmedAmountAtHeight = async (
     },
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const queryAvialableAmount = async (
   chain: CosmosWrapper,
   address: string,
@@ -1262,6 +1443,10 @@ export const queryAvialableAmount = async (
     },
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const instantiateVestingLp = async (
   cm: WalletWrapper,
   codeId: CodeId,
@@ -1283,6 +1468,10 @@ export const instantiateVestingLp = async (
   return res;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const executeVestingLpSetVestingToken = async (
   cm: WalletWrapper,
   contractAddress: string,
@@ -1298,6 +1487,10 @@ export const executeVestingLpSetVestingToken = async (
     },
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const executeVestingLpSetVestingManagers = async (
   cm: WalletWrapper,
   contractAddress: string,
@@ -1313,6 +1506,10 @@ export const executeVestingLpSetVestingManagers = async (
     },
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const instantiateAstroGenerator = async (
   cm: WalletWrapper,
   codeId: CodeId,
@@ -1347,6 +1544,10 @@ export const instantiateAstroGenerator = async (
   return res;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const instantiateAstroIncentives = async (
   cm: WalletWrapper,
   codeId: CodeId,
@@ -1375,6 +1576,10 @@ export const instantiateAstroIncentives = async (
   return res;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const instantiateLockdropVault = async (
   cm: WalletWrapper,
   codeId: CodeId,
@@ -1406,6 +1611,10 @@ export const instantiateLockdropVault = async (
   return res;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const executeLockdropVaultUpdateConfig = async (
   cm: WalletWrapper,
   contractAddress: string,
@@ -1427,6 +1636,10 @@ export const executeLockdropVaultUpdateConfig = async (
     },
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const queryLockdropVaultConfig = async (
   cm: CosmosWrapper,
   contractAddress: string,
@@ -1435,6 +1648,10 @@ export const queryLockdropVaultConfig = async (
     config: {},
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const executeVestingLpVaultUpdateConfig = async (
   cm: WalletWrapper,
   contractAddress: string,
@@ -1458,6 +1675,10 @@ export const executeVestingLpVaultUpdateConfig = async (
     },
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const queryVestingLpVaultConfig = async (
   cm: CosmosWrapper,
   contractAddress: string,
@@ -1466,6 +1687,10 @@ export const queryVestingLpVaultConfig = async (
     config: {},
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const instantiateAstroportOracle = async (
   cm: WalletWrapper,
   codeId: CodeId,
@@ -1489,6 +1714,10 @@ export const instantiateAstroportOracle = async (
   return res;
 };
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const executeAstroportOracleSetAssetInfos = async (
   cm: WalletWrapper,
   contractAddress: string,
@@ -1510,6 +1739,10 @@ export const executeAstroportOracleSetAssetInfos = async (
     ],
   });
 
+// TODO: remove it completely
+/**
+ * @deprecated since version 0.5.0
+ */
 export const instantiateVestingLpVault = async (
   cm: WalletWrapper,
   codeId: CodeId,

--- a/src/tokenfactory.ts
+++ b/src/tokenfactory.ts
@@ -11,18 +11,34 @@ import {
 } from '@neutron-org/cosmjs-types/osmosis/tokenfactory/v1beta1/tx';
 import { Coin } from '@neutron-org/cosmjs-types/cosmos/base/v1beta1/coin';
 
+// TODO: use RPC
+/**
+ * @deprecated since version 0.5.0
+ */
 export interface DenomsFromCreator {
   readonly denoms: readonly string[];
 }
 
+// TODO: use RPC
+/**
+ * @deprecated since version 0.5.0
+ */
 export interface AuthorityMetadata {
   readonly authority_metadata: { readonly Admin: string };
 }
 
+// TODO: use RPC
+/**
+ * @deprecated since version 0.5.0
+ */
 export interface BeforeSendHook {
   readonly contract_addr: string;
 }
 
+// TODO: use RPC
+/**
+ * @deprecated since version 0.5.0
+ */
 export const msgMintDenom = async (
   cmNeutron: WalletWrapper,
   creator: string,
@@ -46,6 +62,10 @@ export const msgMintDenom = async (
   return await cmNeutron.execTx(fee, [msg]);
 };
 
+// TODO: use RPC
+/**
+ * @deprecated since version 0.5.0
+ */
 export const msgCreateDenom = async (
   cmNeutron: WalletWrapper,
   sender: string,
@@ -67,6 +87,10 @@ export const msgCreateDenom = async (
   return await cmNeutron.execTx(fee, [msg]);
 };
 
+// TODO: use RPC
+/**
+ * @deprecated since version 0.5.0
+ */
 export const msgBurn = async (
   cmNeutron: WalletWrapper,
   sender: string,
@@ -95,6 +119,10 @@ export const msgBurn = async (
 };
 
 // Create MsgChangeAdmin message
+// TODO: use RPC
+/**
+ * @deprecated since version 0.5.0
+ */
 export const msgChangeAdmin = async (
   cmNeutron: WalletWrapper,
   creator: string,
@@ -118,6 +146,10 @@ export const msgChangeAdmin = async (
   return await cmNeutron.execTx(fee, [msg]);
 };
 
+// TODO: use RPC
+/**
+ * @deprecated since version 0.5.0
+ */
 export const msgSetBeforeSendHook = async (
   cmNeutron: WalletWrapper,
   creator: string,
@@ -141,6 +173,10 @@ export const msgSetBeforeSendHook = async (
   return await cmNeutron.execTx(fee, [msg]);
 };
 
+// TODO: use RPC
+/**
+ * @deprecated since version 0.5.0
+ */
 export const checkTokenfactoryParams = async (
   sdkUrl: string,
 ): Promise<boolean> => {
@@ -152,6 +188,10 @@ export const checkTokenfactoryParams = async (
   }
 };
 
+// TODO: use RPC
+/**
+ * @deprecated since version 0.5.0
+ */
 export const getDenomsFromCreator = async (
   sdkUrl: string,
   creator: string,
@@ -163,6 +203,10 @@ export const getDenomsFromCreator = async (
   return res.data;
 };
 
+// TODO: use RPC
+/**
+ * @deprecated since version 0.5.0
+ */
 export const getAuthorityMetadata = async (
   sdkUrl: string,
   denom: string,
@@ -174,6 +218,10 @@ export const getAuthorityMetadata = async (
   return res.data;
 };
 
+// TODO: use RPC
+/**
+ * @deprecated since version 0.5.0
+ */
 export const getBeforeSendHook = async (
   sdkUrl: string,
   denom: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,6 +124,9 @@ export type PauseInfoResponse = {
 // Strategy defines a permission strategy in the chain manager.
 export type Strategy = any;
 
+/**
+ * @deprecated since version 0.5.0
+ */
 export const NeutronContract = {
   IBC_TRANSFER: 'ibc_transfer.wasm',
   MSG_RECEIVER: 'msg_receiver.wasm',

--- a/src/types.ts
+++ b/src/types.ts
@@ -385,15 +385,27 @@ export class Wallet {
 export type CodeId = number;
 
 // DenomTraceResponse is the response model for the ibc transfer denom trace query.
+// TODO: use rpc authogeneration
+/**
+ * @deprecated since version 0.5.0
+ */
 export type DenomTraceResponse = {
   path?: string;
   base_denom?: string;
 };
 
+// TODO: use rpc authogeneration
+/**
+ * @deprecated since version 0.5.0
+ */
 export type TotalSupplyByDenomResponse = {
   amount: Coin;
 };
 
+// TODO: use rpc authogeneration
+/**
+ * @deprecated since version 0.5.0
+ */
 export type DenomMetadataResponse = {
   metadatas: [
     {
@@ -419,6 +431,10 @@ export type DenomMetadataResponse = {
   };
 };
 
+// TODO: use rpc authogeneration
+/**
+ * @deprecated since version 0.5.0
+ */
 // TotalBurnedNeutronsAmountResponse is the response model for the feeburner's total-burned-neutrons.
 export type TotalBurnedNeutronsAmountResponse = {
   total_burned_neutrons_amount: {

--- a/src/walletWrapper.ts
+++ b/src/walletWrapper.ts
@@ -24,10 +24,18 @@ export class WalletWrapper {
     public debug = false,
   ) {}
 
+  /**
+   * @deprecated since version 0.5.0
+   * use StargateClient.getAllBalances("address") instead
+   */
   async queryBalances(): Promise<Coin[]> {
     return await this.chain.queryBalances(this.wallet.address);
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   * use StargateClient.getBalance("address", "denom") instead
+   */
   async queryDenomBalance(denom: string): Promise<number> {
     return await this.chain.queryDenomBalance(this.wallet.address, denom);
   }
@@ -156,6 +164,7 @@ export class WalletWrapper {
   /**
    * msgSend processes a transfer, waits two blocks and returns the tx hash.
    * @deprecated since version 0.5.0
+   * Use SigningStargateClient.sendTokens instead
    */
   async msgSend(
     to: string,
@@ -185,8 +194,13 @@ export class WalletWrapper {
     return res;
   }
 
-  // TODO: move out from walletWrapper?
-  // Q: Do we need it in neutronjsplus?
+  // TODO: move to dao
+  // TODO: is it legacy proposal submission method?
+  /**
+   * msgSend processes a transfer, waits two blocks and returns the tx hash.
+   * @deprecated since version 0.5.0
+   * Use dao.submitParameterChangeProposal instead
+   */
   async msgSendDirectProposal(
     subspace: string,
     key: string,

--- a/src/walletWrapper.ts
+++ b/src/walletWrapper.ts
@@ -32,6 +32,9 @@ export class WalletWrapper {
     return await this.chain.queryDenomBalance(this.wallet.address, denom);
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async execTx(
     fee: StdFee | 'auto' | number,
     msgs: EncodeObject[],
@@ -70,7 +73,11 @@ export class WalletWrapper {
     throw error;
   }
 
-  // storeWasm stores the wasm code by the passed path on the blockchain.
+  /**
+   * storeWasm stores the wasm code by the passed path on the blockchain.
+   * @deprecated since version 0.5.0
+   * Please use SigningCosmWasmClient instead
+   */
   async storeWasm(fileName: string): Promise<CodeId> {
     const sender = this.wallet.address;
     const wasmCode = await this.getContractBinary(fileName);
@@ -81,6 +88,10 @@ export class WalletWrapper {
     return res.codeId;
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   * Please use SigningCosmWasmClient instead
+   */
   async instantiateContract(
     codeId: number,
     msg: any,
@@ -101,6 +112,10 @@ export class WalletWrapper {
     return res.contractAddress;
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   * Please use SigningCosmWasmClient instead
+   */
   async migrateContract(
     contract: string,
     codeId: number,
@@ -113,6 +128,10 @@ export class WalletWrapper {
     });
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   * Please use SigningCosmWasmClient instead
+   */
   async executeContract(
     contract: string,
     msg: any,
@@ -136,6 +155,7 @@ export class WalletWrapper {
 
   /**
    * msgSend processes a transfer, waits two blocks and returns the tx hash.
+   * @deprecated since version 0.5.0
    */
   async msgSend(
     to: string,
@@ -165,6 +185,8 @@ export class WalletWrapper {
     return res;
   }
 
+  // TODO: move out from walletWrapper?
+  // Q: Do we need it in neutronjsplus?
   async msgSendDirectProposal(
     subspace: string,
     key: string,
@@ -202,7 +224,9 @@ export class WalletWrapper {
     return await this.execTx(fee, [msg]);
   }
 
-  /* simulateFeeBurning simulates fee burning via send tx.
+  /**
+   * simulateFeeBurning simulates fee burning via send tx.
+   * @deprecated since version 0.5.0
    */
   async simulateFeeBurning(amount: number): Promise<IndexedTx> {
     const fee = {
@@ -224,6 +248,7 @@ export class WalletWrapper {
 
   /**
    * msgRemoveInterchainQuery sends transaction to remove interchain query, waits two blocks and returns the tx hash.
+   * @deprecated since version 0.5.0
    */
   async msgRemoveInterchainQuery(
     queryId: bigint,
@@ -250,6 +275,7 @@ export class WalletWrapper {
 
   /**
    * msgIBCTransfer processes an IBC transfer, waits two blocks and returns the tx hash.
+   * @deprecated since version 0.5.0
    */
   async msgIBCTransfer(
     sourcePort: string,
@@ -286,6 +312,9 @@ export class WalletWrapper {
     return await this.execTx(fee, [msg]);
   }
 
+  /**
+   * @deprecated since version 0.5.0
+   */
   async getContractBinary(fileName: string): Promise<Buffer> {
     return fsPromise.readFile(path.resolve(this.contractsPath, fileName));
   }


### PR DESCRIPTION
Deprecate methods that can be called by autogenerated grpc or just needs to be moved to neutron-integration-tests