### PR TITLE
fix: cron execution stage type

### DIFF
--- a/src/dao.ts
+++ b/src/dao.ts
@@ -7,7 +7,7 @@ import {
 } from './types';
 import {
   addCronScheduleProposal,
-    addScheduleBindings,
+  addScheduleBindings,
   AddSchedule,
   chainManagerWrapper,
   clearAdminProposal,
@@ -28,7 +28,7 @@ import {
   pinCodesCustomAuthorityProposal,
   pinCodesProposal,
   removeCronScheduleProposal,
-    removeScheduleBindings,
+  removeScheduleBindings,
   RemoveSchedule,
   SendProposalInfo,
   unpinCodesProposal,
@@ -135,7 +135,7 @@ export const getProposalModules = async (
         address: timelockAddr,
       };
       // eslint-disable-next-line no-empty
-    } catch (e) { }
+    } catch (e) {}
 
     proposalsStructure[moduleType] = {
       address: proposalModule.address,
@@ -213,7 +213,7 @@ export const getSubDaoContracts = async (
 };
 
 export class Dao {
-  constructor(private client: CosmWasmClient, public contracts: DaoContracts) { }
+  constructor(private client: CosmWasmClient, public contracts: DaoContracts) {}
 
   async checkPassedProposal(proposalId: number) {
     await getWithAttempts(
@@ -297,12 +297,12 @@ export class Dao {
       voting_power_at_height:
         typeof height === 'undefined'
           ? {
-            address: addr,
-          }
+              address: addr,
+            }
           : {
-            address: addr,
-            height: height,
-          },
+              address: addr,
+              height: height,
+            },
     });
   }
 
@@ -384,7 +384,7 @@ export class DaoMember {
     private client: SigningCosmWasmClient,
     public user: string,
     private denom: string,
-  ) { }
+  ) {}
 
   /**
    * voteYes  vote 'yes' for given proposal.
@@ -532,7 +532,7 @@ export class DaoMember {
     if (proposalId < 0) {
       throw new Error(
         'failed to get proposal ID from the proposal creation tx attributes: ' +
-        JSON.stringify(proposalTx.events),
+          JSON.stringify(proposalTx.events),
       );
     }
     return proposalId;
@@ -752,7 +752,7 @@ export class DaoMember {
     if (proposalId < 0) {
       throw new Error(
         'failed to get proposal ID from the proposal creation tx attributes: ' +
-        JSON.stringify(proposalTx.events),
+          JSON.stringify(proposalTx.events),
       );
     }
     return proposalId;
@@ -1034,7 +1034,7 @@ export class DaoMember {
     if (proposalId < 0) {
       throw new Error(
         'failed to get proposal ID from the proposal creation tx attributes: ' +
-        JSON.stringify(proposalTx.events),
+          JSON.stringify(proposalTx.events),
       );
     }
     return proposalId1;
@@ -1739,8 +1739,8 @@ export class DaoMember {
       );
     } else {
       message = bindings
-          ? removeScheduleBindings(info.name)
-          : removeCronScheduleProposal(info);
+        ? removeScheduleBindings(info.name)
+        : removeCronScheduleProposal(info);
     }
     return await this.submitSingleChoiceProposal(
       title,

--- a/src/proposal.ts
+++ b/src/proposal.ts
@@ -149,12 +149,12 @@ export type MultiChoiceProposal = {
   readonly choices: CheckedMultipleChoiceOption[];
   // Proposal status (Open, rejected, executed, execution failed, closed, passed)
   readonly status:
-  | 'open'
-  | 'rejected'
-  | 'passed'
-  | 'executed'
-  | 'closed'
-  | 'execution_failed';
+    | 'open'
+    | 'rejected'
+    | 'passed'
+    | 'executed'
+    | 'closed'
+    | 'execution_failed';
   // Voting settings (threshold, quorum, etc.)
   readonly voting_strategy: VotingStrategy;
   // The total power when the proposal started (used to calculate percentages)

--- a/src/proposal.ts
+++ b/src/proposal.ts
@@ -753,7 +753,7 @@ export interface AddSchedule {
   name: string;
   period: number;
   msgs: MsgExecuteContract[];
-  execution_stage: string;
+  execution_stage: number;
 }
 
 export interface RemoveSchedule {


### PR DESCRIPTION
According to [proto](https://github.com/neutron-org/neutron/blob/55d8cb7ae4b5ba487307b6faeaf4a7481af73052/proto/neutron/cron/schedule.proto#L8-L14), the schedule's `execution_stage` field is an int-based enum, whereas in neutronjsplus it is a string. This mistake produces the following warning in integration tests. The integration tests pass and nothing fails due to TS's weak types.

<img width="872" alt="image" src="https://github.com/user-attachments/assets/8ad933d2-5d45-4d61-972c-a019e287fbf1">

This PR fixes the type and runs `yarn fmt`. When neutronjsplus version is updated in integration-tests repo, will just result in the warning disappearance. Afaik, no special changes will be required to be made to integration-tests repo.