### PR TITLE
Feat/chainmanager globalfee dynamicfee ccv params #NTRN-408

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@cosmjs/cosmwasm-stargate": "^0.32.4",
     "@cosmjs/proto-signing": "^0.32.4",
     "@cosmjs/stargate": "0.32.4",
-    "@neutron-org/neutronjs": "https://github.com/neutron-org/neutronjs.git#7f45328320b53b4fa2b572bc25bb96bf80260181",
+    "@neutron-org/neutronjs": "https://github.com/neutron-org/neutronjs.git#95a719604fecba39de5540b6ac99ded3e7aacfaa",
     "axios": "1.6.0",
     "bip39": "^3.1.0",
     "long": "^5.2.1",

--- a/src/dao.ts
+++ b/src/dao.ts
@@ -36,6 +36,7 @@ import {
   updateAdminProposal,
   updateConsensusParamsProposal,
   upgradeProposal,
+  ConsumerParams,
 } from './proposal';
 import {
   Contract,
@@ -1403,6 +1404,27 @@ export class DaoMember {
     title: string,
     description: string,
     message: ParamsGlobalfeeInfo,
+    amount: string,
+    fee = {
+      gas: '4000000',
+      amount: [{ denom: this.denom, amount: '10000' }],
+    },
+  ): Promise<number> {
+    return await this.submitSingleChoiceProposal(
+      title,
+      description,
+      [chainManagerWrapper(chainManagerAddress, message)],
+      amount,
+      'single',
+      fee,
+    );
+  }
+
+  async submitUpdateParamsConsumerProposal(
+    chainManagerAddress: string,
+    title: string,
+    description: string,
+    message: ConsumerParams,
     amount: string,
     fee = {
       gas: '4000000',

--- a/src/dao.ts
+++ b/src/dao.ts
@@ -36,7 +36,6 @@ import {
   updateAdminProposal,
   updateConsensusParamsProposal,
   upgradeProposal,
-  ConsumerParams,
 } from './proposal';
 import {
   Contract,
@@ -63,6 +62,8 @@ import {
   VotingCw4Module,
   VotingVaultsModule,
 } from './dao_types';
+
+import { ConsumerParams } from '@neutron-org/neutronjs/interchain_security/ccv/v1/shared_consumer';
 
 export const getVotingModule = async (
   client: CosmWasmClient,

--- a/src/dao.ts
+++ b/src/dao.ts
@@ -1752,7 +1752,12 @@ export class DaoMember {
     const message = chainManagerWrapper(
       chainManagerAddress,
       bindings
-        ? addScheduleBindings(info.name, info.period, info.msgs)
+        ? addScheduleBindings(
+            info.name,
+            info.period,
+            info.msgs,
+            info.execution_stage,
+          )
         : addCronScheduleProposal(info),
     );
     return await this.submitSingleChoiceProposal(

--- a/src/proposal.ts
+++ b/src/proposal.ts
@@ -739,12 +739,14 @@ export const addScheduleBindings = (
   name: string,
   period: number,
   msgs: MsgExecuteContract[],
+  executionStage: string,
 ): any => ({
   custom: {
     add_schedule: {
       name,
       period,
       msgs,
+      execution_stage: executionStage,
     },
   },
 });

--- a/src/proposal.ts
+++ b/src/proposal.ts
@@ -220,6 +220,47 @@ export type ConsensusParams = {
   };
 };
 
+export type ConsumerParams = {
+  enabled: boolean;
+  /// /////////////////////
+  /// Distribution Params
+  /// Number of blocks between ibc-token-transfers from the consumer chain to
+  /// the provider chain. Note that at this transmission event a fraction of
+  /// the accumulated tokens are divided and sent consumer redistribution
+  /// address.
+  blocks_per_distribution_transmission: number;
+  /// Channel, and provider-chain receiving address to send distribution token
+  /// transfers over. These parameters is auto-set during the consumer <->
+  /// provider handshake procedure.
+  distribution_transmission_channel: string;
+  provider_fee_pool_addr_str: string;
+  /// Sent CCV related IBC packets will timeout after this duration
+  ccv_timeout_period: string; // Duration
+  /// Sent transfer related IBC packets will timeout after this duration
+  transfer_timeout_period: string; // Duration
+  /// The fraction of tokens allocated to the consumer redistribution address
+  /// during distribution events. The fraction is a string representing a
+  /// decimal number. For example "0.75" would represent 75%.
+  consumer_redistribution_fraction: string;
+  /// The number of historical info entries to persist in store.
+  /// This param is a part of the cosmos sdk staking module. In the case of
+  /// a ccv enabled consumer chain, the ccv module acts as the staking module.
+  historical_entries: number;
+  /// Unbonding period for the consumer,
+  /// which should be smaller than that of the provider in general.
+  unbonding_period: string; // Duration
+  /// !!! DEPRECATED !!! soft_opt_out_threshold is deprecated. see docs/docs/adrs/adr-015-partial-set-security.md
+  soft_opt_out_threshold: string;
+  /// Reward denoms. These are the denominations which are allowed to be sent to
+  /// the provider as rewards.
+  reward_denoms: Array<string>;
+  /// Provider-originated reward denoms. These are denoms coming from the
+  /// provider which are allowed to be used as rewards. e.g. "uatom"
+  provider_reward_denoms: Array<string>;
+  /// The period after which a consumer can retry sending a throttled packet.
+  retry_delay_period: string; // Duration
+};
+
 export type DecCoin = {
   denom: string;
   amount: string;
@@ -744,6 +785,22 @@ export const updateDynamicFeesParamsProposal = (
         proposal_execute_message: {
           message: JSON.stringify({
             '@type': '/neutron.dynamicfees.v1.MsgUpdateParams',
+            authority: ADMIN_MODULE_ADDRESS,
+            params,
+          }),
+        },
+      },
+    },
+  },
+});
+
+export const updateConsumerParamsProposal = (params: ConsumerParams): any => ({
+  custom: {
+    submit_admin_proposal: {
+      admin_proposal: {
+        proposal_execute_message: {
+          message: JSON.stringify({
+            '@type': '"/interchain_security.ccv.consumer.v1.MsgUpdateParams"',
             authority: ADMIN_MODULE_ADDRESS,
             params,
           }),

--- a/src/proposal.ts
+++ b/src/proposal.ts
@@ -221,47 +221,6 @@ export type ConsensusParams = {
   };
 };
 
-// export type ConsumerParams = {
-//   enabled: boolean;
-//   /// /////////////////////
-//   /// Distribution Params
-//   /// Number of blocks between ibc-token-transfers from the consumer chain to
-//   /// the provider chain. Note that at this transmission event a fraction of
-//   /// the accumulated tokens are divided and sent consumer redistribution
-//   /// address.
-//   blocks_per_distribution_transmission: number;
-//   /// Channel, and provider-chain receiving address to send distribution token
-//   /// transfers over. These parameters is auto-set during the consumer <->
-//   /// provider handshake procedure.
-//   distribution_transmission_channel: string;
-//   provider_fee_pool_addr_str: string;
-//   /// Sent CCV related IBC packets will timeout after this duration
-//   ccv_timeout_period: string; // Duration
-//   /// Sent transfer related IBC packets will timeout after this duration
-//   transfer_timeout_period: string; // Duration
-//   /// The fraction of tokens allocated to the consumer redistribution address
-//   /// during distribution events. The fraction is a string representing a
-//   /// decimal number. For example "0.75" would represent 75%.
-//   consumer_redistribution_fraction: string;
-//   /// The number of historical info entries to persist in store.
-//   /// This param is a part of the cosmos sdk staking module. In the case of
-//   /// a ccv enabled consumer chain, the ccv module acts as the staking module.
-//   historical_entries: number;
-//   /// Unbonding period for the consumer,
-//   /// which should be smaller than that of the provider in general.
-//   unbonding_period: string; // Duration
-//   /// !!! DEPRECATED !!! soft_opt_out_threshold is deprecated. see docs/docs/adrs/adr-015-partial-set-security.md
-//   soft_opt_out_threshold: string;
-//   /// Reward denoms. These are the denominations which are allowed to be sent to
-//   /// the provider as rewards.
-//   reward_denoms: Array<string>;
-//   /// Provider-originated reward denoms. These are denoms coming from the
-//   /// provider which are allowed to be used as rewards. e.g. "uatom"
-//   provider_reward_denoms: Array<string>;
-//   /// The period after which a consumer can retry sending a throttled packet.
-//   retry_delay_period: string; // Duration
-// };
-
 export type DecCoin = {
   denom: string;
   amount: string;

--- a/src/proposal.ts
+++ b/src/proposal.ts
@@ -1,6 +1,7 @@
 import { Coin } from '@cosmjs/proto-signing';
 import { ADMIN_MODULE_ADDRESS } from './constants';
 import { MsgExecuteContract } from '@neutron-org/neutronjs/neutron/cron/schedule';
+import { ConsumerParams } from '@neutron-org/neutronjs/interchain_security/ccv/v1/shared_consumer';
 
 export type ParamChangeProposalInfo = {
   title: string;
@@ -220,46 +221,46 @@ export type ConsensusParams = {
   };
 };
 
-export type ConsumerParams = {
-  enabled: boolean;
-  /// /////////////////////
-  /// Distribution Params
-  /// Number of blocks between ibc-token-transfers from the consumer chain to
-  /// the provider chain. Note that at this transmission event a fraction of
-  /// the accumulated tokens are divided and sent consumer redistribution
-  /// address.
-  blocks_per_distribution_transmission: number;
-  /// Channel, and provider-chain receiving address to send distribution token
-  /// transfers over. These parameters is auto-set during the consumer <->
-  /// provider handshake procedure.
-  distribution_transmission_channel: string;
-  provider_fee_pool_addr_str: string;
-  /// Sent CCV related IBC packets will timeout after this duration
-  ccv_timeout_period: string; // Duration
-  /// Sent transfer related IBC packets will timeout after this duration
-  transfer_timeout_period: string; // Duration
-  /// The fraction of tokens allocated to the consumer redistribution address
-  /// during distribution events. The fraction is a string representing a
-  /// decimal number. For example "0.75" would represent 75%.
-  consumer_redistribution_fraction: string;
-  /// The number of historical info entries to persist in store.
-  /// This param is a part of the cosmos sdk staking module. In the case of
-  /// a ccv enabled consumer chain, the ccv module acts as the staking module.
-  historical_entries: number;
-  /// Unbonding period for the consumer,
-  /// which should be smaller than that of the provider in general.
-  unbonding_period: string; // Duration
-  /// !!! DEPRECATED !!! soft_opt_out_threshold is deprecated. see docs/docs/adrs/adr-015-partial-set-security.md
-  soft_opt_out_threshold: string;
-  /// Reward denoms. These are the denominations which are allowed to be sent to
-  /// the provider as rewards.
-  reward_denoms: Array<string>;
-  /// Provider-originated reward denoms. These are denoms coming from the
-  /// provider which are allowed to be used as rewards. e.g. "uatom"
-  provider_reward_denoms: Array<string>;
-  /// The period after which a consumer can retry sending a throttled packet.
-  retry_delay_period: string; // Duration
-};
+// export type ConsumerParams = {
+//   enabled: boolean;
+//   /// /////////////////////
+//   /// Distribution Params
+//   /// Number of blocks between ibc-token-transfers from the consumer chain to
+//   /// the provider chain. Note that at this transmission event a fraction of
+//   /// the accumulated tokens are divided and sent consumer redistribution
+//   /// address.
+//   blocks_per_distribution_transmission: number;
+//   /// Channel, and provider-chain receiving address to send distribution token
+//   /// transfers over. These parameters is auto-set during the consumer <->
+//   /// provider handshake procedure.
+//   distribution_transmission_channel: string;
+//   provider_fee_pool_addr_str: string;
+//   /// Sent CCV related IBC packets will timeout after this duration
+//   ccv_timeout_period: string; // Duration
+//   /// Sent transfer related IBC packets will timeout after this duration
+//   transfer_timeout_period: string; // Duration
+//   /// The fraction of tokens allocated to the consumer redistribution address
+//   /// during distribution events. The fraction is a string representing a
+//   /// decimal number. For example "0.75" would represent 75%.
+//   consumer_redistribution_fraction: string;
+//   /// The number of historical info entries to persist in store.
+//   /// This param is a part of the cosmos sdk staking module. In the case of
+//   /// a ccv enabled consumer chain, the ccv module acts as the staking module.
+//   historical_entries: number;
+//   /// Unbonding period for the consumer,
+//   /// which should be smaller than that of the provider in general.
+//   unbonding_period: string; // Duration
+//   /// !!! DEPRECATED !!! soft_opt_out_threshold is deprecated. see docs/docs/adrs/adr-015-partial-set-security.md
+//   soft_opt_out_threshold: string;
+//   /// Reward denoms. These are the denominations which are allowed to be sent to
+//   /// the provider as rewards.
+//   reward_denoms: Array<string>;
+//   /// Provider-originated reward denoms. These are denoms coming from the
+//   /// provider which are allowed to be used as rewards. e.g. "uatom"
+//   provider_reward_denoms: Array<string>;
+//   /// The period after which a consumer can retry sending a throttled packet.
+//   retry_delay_period: string; // Duration
+// };
 
 export type DecCoin = {
   denom: string;

--- a/src/proposal.ts
+++ b/src/proposal.ts
@@ -800,7 +800,7 @@ export const updateConsumerParamsProposal = (params: ConsumerParams): any => ({
       admin_proposal: {
         proposal_execute_message: {
           message: JSON.stringify({
-            '@type': '"/interchain_security.ccv.consumer.v1.MsgUpdateParams"',
+            '@type': '/interchain_security.ccv.consumer.v1.MsgUpdateParams',
             authority: ADMIN_MODULE_ADDRESS,
             params,
           }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1184,9 +1184,9 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@neutron-org/neutronjs@https://github.com/neutron-org/neutronjs.git#7f45328320b53b4fa2b572bc25bb96bf80260181":
+"@neutron-org/neutronjs@https://github.com/neutron-org/neutronjs.git#95a719604fecba39de5540b6ac99ded3e7aacfaa":
   version "4.2.0"
-  resolved "https://github.com/neutron-org/neutronjs.git#7f45328320b53b4fa2b572bc25bb96bf80260181"
+  resolved "https://github.com/neutron-org/neutronjs.git#95a719604fecba39de5540b6ac99ded3e7aacfaa"
 
 "@noble/curves@1.4.2", "@noble/curves@~1.4.0":
   version "1.4.2"


### PR DESCRIPTION
The PR adds a method for submiting proposals to change the parameters of the `consumer` module. The method for creating `cron` schedules via bindings has been corrected (the execution_stage argument was missed).

Task definition: Add updateParamsPersimmon to chain manager (https://github.com/neutron-org/neutron-dao/tree/main/contracts/dao/neutron-chain-manager) for the following modules:
- consumer
- dynamicfees
- globalfee


All prs:
https://github.com/neutron-org/neutronjs/pull/10
https://github.com/neutron-org/neutronjsplus/pull/69
https://github.com/neutron-org/neutron-integration-tests/pull/368
https://github.com/neutron-org/neutron-dao/pull/116
https://github.com/neutron-org/neutron-std/pull/8
https://github.com/neutron-org/neutron/pull/765