### PR TITLE
update neutronjs to ibcv10 version one and remove ics #ntrn-504

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@cosmjs/cosmwasm-stargate": "^0.32.4",
     "@cosmjs/proto-signing": "^0.32.4",
     "@cosmjs/stargate": "0.32.4",
-    "@neutron-org/neutronjs": "https://github.com/neutron-org/neutronjs.git#a605a124e5fbae81af768a7910166fa3aa3a31f8",
+    "@neutron-org/neutronjs": "https://github.com/neutron-org/neutronjs.git#64bc869d2e780614f3b09dfd2ba44f5f63da1838",
     "axios": "1.6.0",
     "bip39": "^3.1.0",
     "long": "^5.2.1",

--- a/src/dao.ts
+++ b/src/dao.ts
@@ -63,8 +63,6 @@ import {
   VotingVaultsModule,
 } from './dao_types';
 
-import { ConsumerParams } from '@neutron-org/neutronjs/interchain_security/ccv/v1/shared_consumer';
-
 export const getVotingModule = async (
   client: CosmWasmClient,
   daoAddress: string,
@@ -1405,27 +1403,6 @@ export class DaoMember {
     title: string,
     description: string,
     message: ParamsGlobalfeeInfo,
-    amount: string,
-    fee = {
-      gas: '4000000',
-      amount: [{ denom: this.denom, amount: '10000' }],
-    },
-  ): Promise<number> {
-    return await this.submitSingleChoiceProposal(
-      title,
-      description,
-      [chainManagerWrapper(chainManagerAddress, message)],
-      amount,
-      'single',
-      fee,
-    );
-  }
-
-  async submitUpdateParamsConsumerProposal(
-    chainManagerAddress: string,
-    title: string,
-    description: string,
-    message: ConsumerParams,
     amount: string,
     fee = {
       gas: '4000000',

--- a/src/proposal.ts
+++ b/src/proposal.ts
@@ -1,7 +1,6 @@
 import { Coin } from '@cosmjs/proto-signing';
 import { ADMIN_MODULE_ADDRESS } from './constants';
 import { MsgExecuteContract } from '@neutron-org/neutronjs/neutron/cron/schedule';
-import { ConsumerParams } from '@neutron-org/neutronjs/interchain_security/ccv/v1/shared_consumer';
 
 export type ParamChangeProposalInfo = {
   title: string;
@@ -862,22 +861,6 @@ export const updateDynamicFeesParamsProposal = (
         proposal_execute_message: {
           message: JSON.stringify({
             '@type': '/neutron.dynamicfees.v1.MsgUpdateParams',
-            authority: ADMIN_MODULE_ADDRESS,
-            params,
-          }),
-        },
-      },
-    },
-  },
-});
-
-export const updateConsumerParamsProposal = (params: ConsumerParams): any => ({
-  custom: {
-    submit_admin_proposal: {
-      admin_proposal: {
-        proposal_execute_message: {
-          message: JSON.stringify({
-            '@type': '/interchain_security.ccv.consumer.v1.MsgUpdateParams',
             authority: ADMIN_MODULE_ADDRESS,
             params,
           }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,9 +1028,9 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@neutron-org/neutronjs@https://github.com/neutron-org/neutronjs.git#9100cb454e9c90ea4b7c725466e5a2f1061e86c2":
+"@neutron-org/neutronjs@https://github.com/neutron-org/neutronjs.git#64bc869d2e780614f3b09dfd2ba44f5f63da1838":
   version "4.2.0"
-  resolved "https://github.com/neutron-org/neutronjs.git#9100cb454e9c90ea4b7c725466e5a2f1061e86c2"
+  resolved "https://github.com/neutron-org/neutronjs.git#64bc869d2e780614f3b09dfd2ba44f5f63da1838"
 
 "@noble/curves@1.4.2", "@noble/curves@~1.4.0":
   version "1.4.2"


### PR DESCRIPTION
update neutronjs to ibcv10 version one and remove ics


PR's:
- [neutron](https://github.com/neutron-org/neutron/pull/904) - Updates ibc-go, wasmd, admin-module, slinky; fixed unit tests;
- [admin-module](https://github.com/neutron-org/admin-module/pull/13) - updated ibc-go to v10.1.1;
- [slinky](https://github.com/neutron-org/connect/pull/1) - updated interchain security to v7 since it depends on ibc-go version;
- [ts-relayer](https://github.com/neutron-org/ts-relayer/pull/1) - fixed packet parsing because of ibcv10 removal of fields from events;
- [neutron-integration-tests](https://github.com/neutron-org/neutron-integration-tests/pull/386) - use updated neutronjs, neutronjsplus, ts-relayer. use denom insetead of removed denomTrace
- [neutronjsplus](https://github.com/neutron-org/neutronjsplus/pull/84) - update neutronjs to ibcv10 version one and remove ics;
- [neutronjs](https://github.com/neutron-org/neutronjs/pull/17) - update ibcgo, neutron, slinky, admin-module, wasmd
