### PR TITLE
feat: add param for disabling interchain fees #ntrn-503

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@cosmjs/cosmwasm-stargate": "^0.32.4",
     "@cosmjs/proto-signing": "^0.32.4",
     "@cosmjs/stargate": "0.32.4",
-    "@neutron-org/neutronjs": "https://github.com/neutron-org/neutronjs.git#9100cb454e9c90ea4b7c725466e5a2f1061e86c2",
+    "@neutron-org/neutronjs": "https://github.com/neutron-org/neutronjs.git#b9cbc1f31621584219f46a49783704c51e2f2abc",
     "axios": "1.6.0",
     "bip39": "^3.1.0",
     "long": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@cosmjs/cosmwasm-stargate": "^0.32.4",
     "@cosmjs/proto-signing": "^0.32.4",
     "@cosmjs/stargate": "0.32.4",
-    "@neutron-org/neutronjs": "https://github.com/neutron-org/neutronjs.git#b9cbc1f31621584219f46a49783704c51e2f2abc",
+    "@neutron-org/neutronjs": "https://github.com/neutron-org/neutronjs.git#1c642d1658173e8e3f64f59373d3a47879e35a16",
     "axios": "1.6.0",
     "bip39": "^3.1.0",
     "long": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@cosmjs/cosmwasm-stargate": "^0.32.4",
     "@cosmjs/proto-signing": "^0.32.4",
     "@cosmjs/stargate": "0.32.4",
-    "@neutron-org/neutronjs": "https://github.com/neutron-org/neutronjs.git#a605a124e5fbae81af768a7910166fa3aa3a31f8",
+    "@neutron-org/neutronjs": "https://github.com/neutron-org/neutronjs.git#9100cb454e9c90ea4b7c725466e5a2f1061e86c2",
     "axios": "1.6.0",
     "bip39": "^3.1.0",
     "long": "^5.2.1",

--- a/src/dao.ts
+++ b/src/dao.ts
@@ -1564,6 +1564,7 @@ export class DaoMember {
     description: string,
     message: ParamsFeerefunderInfo = {
       min_fee: { recv_fee: null, ack_fee: null, timeout_fee: null },
+      fee_enabled: true,
     },
     amount: string,
   ): Promise<number> {

--- a/src/proposal.ts
+++ b/src/proposal.ts
@@ -135,6 +135,7 @@ export type ParamsTransferInfo = {
 };
 
 export type ParamsFeerefunderInfo = {
+  fee_enabled: boolean;
   min_fee: {
     recv_fee: any;
     ack_fee: any;

--- a/src/proposal.ts
+++ b/src/proposal.ts
@@ -619,6 +619,7 @@ export const updateFeerefunderParamsProposal = (
             authority: ADMIN_MODULE_ADDRESS,
             params: {
               min_fee: info.min_fee,
+              fee_enabled: info.fee_enabled,
             },
           }),
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,9 +1028,9 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@neutron-org/neutronjs@https://github.com/neutron-org/neutronjs.git#8fcf06090c9591557fd149944cdc6d493d2728f6":
+"@neutron-org/neutronjs@https://github.com/neutron-org/neutronjs.git#b9cbc1f31621584219f46a49783704c51e2f2abc":
   version "4.2.0"
-  resolved "https://github.com/neutron-org/neutronjs.git#8fcf06090c9591557fd149944cdc6d493d2728f6"
+  resolved "https://github.com/neutron-org/neutronjs.git#b9cbc1f31621584219f46a49783704c51e2f2abc"
 
 "@noble/curves@1.4.2", "@noble/curves@~1.4.0":
   version "1.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,9 +1028,9 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@neutron-org/neutronjs@https://github.com/neutron-org/neutronjs.git#a605a124e5fbae81af768a7910166fa3aa3a31f8":
+"@neutron-org/neutronjs@https://github.com/neutron-org/neutronjs.git#9100cb454e9c90ea4b7c725466e5a2f1061e86c2":
   version "4.2.0"
-  resolved "https://github.com/neutron-org/neutronjs.git#a605a124e5fbae81af768a7910166fa3aa3a31f8"
+  resolved "https://github.com/neutron-org/neutronjs.git#9100cb454e9c90ea4b7c725466e5a2f1061e86c2"
 
 "@noble/curves@1.4.2", "@noble/curves@~1.4.0":
   version "1.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,9 +1028,9 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@neutron-org/neutronjs@https://github.com/neutron-org/neutronjs.git#9100cb454e9c90ea4b7c725466e5a2f1061e86c2":
+"@neutron-org/neutronjs@https://github.com/neutron-org/neutronjs.git#a605a124e5fbae81af768a7910166fa3aa3a31f8":
   version "4.2.0"
-  resolved "https://github.com/neutron-org/neutronjs.git#9100cb454e9c90ea4b7c725466e5a2f1061e86c2"
+  resolved "https://github.com/neutron-org/neutronjs.git#a605a124e5fbae81af768a7910166fa3aa3a31f8"
 
 "@noble/curves@1.4.2", "@noble/curves@~1.4.0":
   version "1.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,9 +1028,9 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@neutron-org/neutronjs@https://github.com/neutron-org/neutronjs.git#b9cbc1f31621584219f46a49783704c51e2f2abc":
+"@neutron-org/neutronjs@https://github.com/neutron-org/neutronjs.git#1c642d1658173e8e3f64f59373d3a47879e35a16":
   version "4.2.0"
-  resolved "https://github.com/neutron-org/neutronjs.git#b9cbc1f31621584219f46a49783704c51e2f2abc"
+  resolved "https://github.com/neutron-org/neutronjs.git#1c642d1658173e8e3f64f59373d3a47879e35a16"
 
 "@noble/curves@1.4.2", "@noble/curves@~1.4.0":
   version "1.4.2"


### PR DESCRIPTION
Adds FeeEnabled param to update proposal for feerefunder MsgUpdateParams

https://hadronlabs.atlassian.net/browse/NTRN-503

PR's:
- [neutron](https://github.com/neutron-org/neutron/pull/932) - add EnableFee param
- [integration-tests](https://github.com/neutron-org/neutron-integration-tests/pull/389) - add tests when fee is disabled
- [neutronjsplus](https://github.com/neutron-org/neutronjsplus/pull/86) - add param to update params proposal
- [neutronjs](https://github.com/neutron-org/neutronjs/pull/18) - add param to neutronjs
- [neutron-std](https://github.com/neutron-org/neutron-std/pull/14) - regen neutron feerefunder types
- [neutron-sdk](https://github.com/neutron-org/neutron-sdk/pull/175) - use updated neutron std to modify submit_tx to use Option for fees (None if no fees)
- [neutron-dev-contracts](https://github.com/neutron-org/neutron-dev-contracts/pull/77) - add ability to set empty fees